### PR TITLE
fix: use stableObjectId field for object equality in Node 10+

### DIFF
--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -407,7 +407,7 @@ export class Debuglet extends EventEmitter {
       // This is ignorable.
     }
 
-    if (utils.satisfies(process.version, '>=10 <10.15.2 || >=11 <11.7')) {
+    if (utils.satisfies(process.version, '>=10 <10.15.3 || >=11 <11.7')) {
       if (this.config.capture && this.config.capture.maxDataSize === 0) {
         that.logger.warn(NODE_10_CIRC_REF_MESSAGE);
       }

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -48,6 +48,10 @@ const ALLOW_EXPRESSIONS_MESSAGE = 'Expressions and conditions are not allowed' +
 const NODE_VERSION_MESSAGE =
     'Node.js version not supported. Node.js 5.2.0 and ' +
     ' versions older than 0.12 are not supported.';
+const NODE_10_CIRC_REF_MESSAGE =
+    'capture.maxDataSize=0 is not recommended on Node 10+. See ' +
+    'https://github.com/googleapis/cloud-debug-nodejs/issues/516' +
+    ' for more information.';
 const BREAKPOINT_ACTION_MESSAGE =
     'The only currently supported breakpoint actions' +
     ' are CAPTURE and LOG.';
@@ -401,6 +405,14 @@ export class Debuglet extends EventEmitter {
     } catch (err5) {
       that.logger.warn('Unable to discover source context', err5);
       // This is ignorable.
+    }
+
+    // TODO(kjin): When stableObjectId is added to Node 10, narrow the range
+    // of Node versions for which this warning applies.
+    if (utils.satisfies(process.version, '>=10')) {
+      if (this.config.capture && this.config.capture.maxDataSize === 0) {
+        that.logger.warn(NODE_10_CIRC_REF_MESSAGE);
+      }
     }
 
     // We can register as a debuggee now.

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -47,7 +47,7 @@ const ALLOW_EXPRESSIONS_MESSAGE = 'Expressions and conditions are not allowed' +
     ' See the debug agent documentation at https://goo.gl/ShSm6r.';
 const NODE_VERSION_MESSAGE =
     'Node.js version not supported. Node.js 5.2.0 and ' +
-    ' versions older than 0.12 are not supported.';
+    'versions older than 0.12 are not supported.';
 const NODE_10_CIRC_REF_MESSAGE =
     'capture.maxDataSize=0 is not recommended on Node 10+. See ' +
     'https://github.com/googleapis/cloud-debug-nodejs/issues/516' +
@@ -323,7 +323,7 @@ export class Debuglet extends EventEmitter {
         path.join(workingDir, '..') === workingDir) {
       const message = 'The working directory is a root directory. Disabling ' +
           'to avoid a scan of the entire filesystem for JavaScript files. ' +
-          'Use config \allowRootAsWorkingDirectory` if you really want to ' +
+          'Use config `allowRootAsWorkingDirectory` if you really want to ' +
           'do this.';
       that.logger.error(message);
       that.emit('initError', new Error(message));

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -407,10 +407,9 @@ export class Debuglet extends EventEmitter {
       // This is ignorable.
     }
 
-    if (utils.satisfies(process.version, '>=10 <10.15.3 || >=11 <11.7')) {
-      if (this.config.capture && this.config.capture.maxDataSize === 0) {
-        that.logger.warn(NODE_10_CIRC_REF_MESSAGE);
-      }
+    if (this.config.capture && this.config.capture.maxDataSize === 0 &&
+        utils.satisfies(process.version, '>=10 <10.15.3 || >=11 <11.7')) {
+      that.logger.warn(NODE_10_CIRC_REF_MESSAGE);
     }
 
     // We can register as a debuggee now.

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -49,8 +49,8 @@ const NODE_VERSION_MESSAGE =
     'Node.js version not supported. Node.js 5.2.0 and ' +
     'versions older than 0.12 are not supported.';
 const NODE_10_CIRC_REF_MESSAGE =
-    'capture.maxDataSize=0 is not recommended on Node 10+. See ' +
-    'https://github.com/googleapis/cloud-debug-nodejs/issues/516' +
+    'capture.maxDataSize=0 is not recommended on older versions of Node' +
+    ' 10/11. See https://github.com/googleapis/cloud-debug-nodejs/issues/516' +
     ' for more information.';
 const BREAKPOINT_ACTION_MESSAGE =
     'The only currently supported breakpoint actions' +
@@ -407,9 +407,7 @@ export class Debuglet extends EventEmitter {
       // This is ignorable.
     }
 
-    // TODO(kjin): When stableObjectId is added to Node 10, narrow the range
-    // of Node versions for which this warning applies.
-    if (utils.satisfies(process.version, '>=10')) {
+    if (utils.satisfies(process.version, '>=10 <10.15.2 || >=11 <11.7')) {
       if (this.config.capture && this.config.capture.maxDataSize === 0) {
         that.logger.warn(NODE_10_CIRC_REF_MESSAGE);
       }

--- a/src/agent/state/inspector-state.ts
+++ b/src/agent/state/inspector-state.ts
@@ -509,13 +509,11 @@ class StateResolver {
     const stableObjectId = this.getStableObjectId(value);
     let idx = this.rawVariableTable.findIndex(rawVar => {
       if (rawVar) {
-        // stableObjectId was introduced in Node 10.x.y as a more reliable way
-        // to check object equality, as objectId is unique only to object
-        // mirrors, and therefore monotonically increases on repeated accesses
-        // to the same remote object. If this field is available, use it.
-        // TODO(kjin): When stableObjectId is added to Node 10:
-        // 1. Fill in x.y with the appropriate versions.
-        // 2. Update DT Node inspector versions, and remove `any` casts here.
+        // stableObjectId was introduced in Node 10.15.3/11.7.0 as a more
+        // reliable way to check object equality, as objectId is unique only to
+        // object mirrors, and therefore monotonically increases on repeated
+        // accesses to the same remote object. If this field is available, use
+        // it.
         if (stableObjectId !== NO_STABLE_OBJECT_ID) {
           return rawVar.stableObjectId === stableObjectId;
         } else {

--- a/test/test-circular-code.js
+++ b/test/test-circular-code.js
@@ -1,8 +1,10 @@
-/*1* KEEP THIS CODE AT THE TOP TO AVOID LINE NUMBER CHANGES */ /* jshint shadow:true */
-/*2*/'use strict';
-/*3*/module.exports.foo = function () {
-/*4*/  const a = {};
-/*5*/  const b = { a };
-/*6*/  a.b = b;
-/*7*/  return a;
-/*8*/}
+/* 1* KEEP THIS CODE AT THE TOP TO AVOID LINE NUMBER CHANGES */ /* jshint shadow:true */
+/* 2*/'use strict';
+/* 3*/module.exports.foo = function () {
+/* 4*/  const a = {};
+/* 5*/  const b = { a, c: this };
+/* 6*/  a.b = b;
+/* 7*/  this.x = this;
+/* 8*/  this.y = a;
+/* 9*/  return this;
+/*10*/}

--- a/test/test-circular.ts
+++ b/test/test-circular.ts
@@ -29,6 +29,7 @@ import {Variable} from '../src/types/stackdriver';
 
 const code = require('./test-circular-code.js');
 
+// TODO(kjin): When stableObjectId is added to Node 10, remove this check.
 // the inspector protocol is only used on Node >= 10 and thus isn't
 // tested on earlier versions
 const skipIfInspector = utils.satisfies(process.version, '>=10') ? it.skip : it;

--- a/test/test-circular.ts
+++ b/test/test-circular.ts
@@ -82,34 +82,49 @@ describe(__filename, () => {
           api.wait(brk, (err2) => {
             assert.ifError(err2);
             assert.ok(brk.stackFrames.length >= 1);
-            const locals = brk.stackFrames[0].locals;
+            const locals = [...brk.stackFrames[0].locals].sort(
+                (a, b) => a.name!.localeCompare(b.name!));
             const nonStatusVars =
-                brk.variableTable.filter(entry => entry && !!entry.members) as
-                Variable[];
-            assert.strictEqual(locals.length, 3);
-            // Three locals: a, b, and this (named context here).
-            assert.deepStrictEqual(locals[0], {name: 'a', varTableIndex: 4});
-            assert.deepStrictEqual(locals[1], {name: 'b', varTableIndex: 5});
-            assert.deepStrictEqual(
-                locals[2], {name: 'context', varTableIndex: 6});
+                (brk.variableTable.filter(entry => entry && !!entry.members) as
+                 Variable[]);
+            const statusVarOffset =
+                brk.variableTable.length - nonStatusVars.length;
+            assert.ok(locals.length >= 3);
+            // At least three locals: a, b, and context (alias for this).
+            // In newer versions of inspector, this appears both as this and
+            // as context.
+            const aLocal = locals[0];
+            const bLocal = locals[1];
+            const contextLocal = locals[2];
+            const thisLocal = locals[3];  // Maybe non-existent
+            assert.ok(aLocal && bLocal && contextLocal);
+            assert.ok(
+                !thisLocal ||
+                thisLocal.varTableIndex === contextLocal.varTableIndex);
             // All three non-status entries in the varTable correspond to each
             // of the locals, respectively.
             assert.strictEqual(nonStatusVars.length, 3);
             // Every entry has a truthy members field.
             assert.ok(!nonStatusVars.some(e => !e.members));
-            assert.strictEqual(nonStatusVars[0].members!.length, 1);  // a
+            const aVar = nonStatusVars[aLocal.varTableIndex! - statusVarOffset];
+            const bVar = nonStatusVars[bLocal.varTableIndex! - statusVarOffset];
+            const thisVar =
+                nonStatusVars[contextLocal.varTableIndex! - statusVarOffset];
+            assert.strictEqual(aVar.members!.length, 1);       // a
+            assert.deepStrictEqual(aVar.members![0], bLocal);  // a.b
+            assert.strictEqual(bVar.members!.length, 2);       // b
+            assert.deepStrictEqual(bVar.members![0], aLocal);  // b.a
             assert.deepStrictEqual(
-                nonStatusVars[0].members![0], {name: 'b', varTableIndex: 5});
-            assert.strictEqual(nonStatusVars[1].members!.length, 2);  // b
+                bVar.members![1],
+                {name: 'c', varTableIndex: contextLocal.varTableIndex});
+            assert.strictEqual(thisVar.members!.length, 2);  // this
+            assert.deepStrictEqual(thisVar.members![0], {
+              name: 'x',
+              varTableIndex: contextLocal.varTableIndex
+            });  // this.x
             assert.deepStrictEqual(
-                nonStatusVars[1].members![0], {name: 'a', varTableIndex: 4});
-            assert.deepStrictEqual(
-                nonStatusVars[1].members![1], {name: 'c', varTableIndex: 6});
-            assert.strictEqual(nonStatusVars[2].members!.length, 2);  // context
-            assert.deepStrictEqual(
-                nonStatusVars[2].members![0], {name: 'x', varTableIndex: 6});
-            assert.deepStrictEqual(
-                nonStatusVars[2].members![1], {name: 'y', varTableIndex: 4});
+                thisVar.members![1],
+                {name: 'y', varTableIndex: aLocal.varTableIndex});  // this.y
             api.clear(brk, (err3) => {
               assert.ifError(err3);
               done();

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -309,47 +309,6 @@ describe('Debuglet', () => {
       debuglet.start();
     });
 
-    it('should emit a warning iff maxDataSize = 0 on Node 10', async () => {
-      // TODO(kjin): When stableObjectId is added to Node 10, remove this test.
-      const useInspector = utils.satisfies(process.version, '>=10');
-      const maxDataSizeZeroConfig = Object.assign({}, defaultConfig, {
-        capture: Object.assign({}, defaultConfig.capture, {maxDataSize: 0})
-      });
-      const checkMaxDataSizeWarningForConfig =
-          (config: ResolvedDebugAgentConfig,
-           shouldShowMessage: boolean) => new Promise((resolve, reject) => {
-            const debug = new Debug(
-                {projectId: 'fake-project', credentials: fakeCredentials},
-                packageInfo);
-
-            const debuglet = new Debuglet(debug, config);
-            let text = '';
-            debuglet.logger.warn = (s: string) => {
-              text += s;
-            };
-
-            debuglet.once('initError', reject);
-
-            debuglet.once('started', () => {
-              assert.strictEqual(
-                  text.includes(
-                      'capture.maxDataSize=0 is not recommended on Node 10+'),
-                  shouldShowMessage);
-              debuglet.stop();
-              resolve();
-            });
-
-            debuglet.start();
-          });
-      // Run the actual test cases.
-      // Check what happens if maxDataSize = 0, regardless of Node version.
-      await checkMaxDataSizeWarningForConfig(
-          maxDataSizeZeroConfig, useInspector);
-      // Additionally, check that a warning doesn't get emitted if
-      // maxDataSize != 0.
-      await checkMaxDataSizeWarningForConfig(defaultConfig, false);
-    });
-
     describe('environment variables', () => {
       let env: NodeJS.ProcessEnv;
       beforeEach(() => {

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -22,6 +22,7 @@ import * as proxyquire from 'proxyquire';
 
 import {DebugAgentConfig, ResolvedDebugAgentConfig} from '../src/agent/config';
 import {defaultConfig as DEFAULT_CONFIG} from '../src/agent/config';
+import * as utils from '../src/agent/util/utils';
 import {Debuggee} from '../src/debuggee';
 import * as stackdriver from '../src/types/stackdriver';
 
@@ -306,6 +307,47 @@ describe('Debuglet', () => {
       });
 
       debuglet.start();
+    });
+
+    it('should emit a warning iff maxDataSize = 0 on Node 10', async () => {
+      // TODO(kjin): When stableObjectId is added to Node 10, remove this test.
+      const useInspector = utils.satisfies(process.version, '>=10');
+      const maxDataSizeZeroConfig = Object.assign({}, defaultConfig, {
+        capture: Object.assign({}, defaultConfig.capture, {maxDataSize: 0})
+      });
+      const checkMaxDataSizeWarningForConfig =
+          (config: ResolvedDebugAgentConfig,
+           shouldShowMessage: boolean) => new Promise((resolve, reject) => {
+            const debug = new Debug(
+                {projectId: 'fake-project', credentials: fakeCredentials},
+                packageInfo);
+
+            const debuglet = new Debuglet(debug, config);
+            let text = '';
+            debuglet.logger.warn = (s: string) => {
+              text += s;
+            };
+
+            debuglet.once('initError', reject);
+
+            debuglet.once('started', () => {
+              assert.strictEqual(
+                  text.includes(
+                      'capture.maxDataSize=0 is not recommended on Node 10+'),
+                  shouldShowMessage);
+              debuglet.stop();
+              resolve();
+            });
+
+            debuglet.start();
+          });
+      // Run the actual test cases.
+      // Check what happens if maxDataSize = 0, regardless of Node version.
+      await checkMaxDataSizeWarningForConfig(
+          maxDataSizeZeroConfig, useInspector);
+      // Additionally, check that a warning doesn't get emitted if
+      // maxDataSize != 0.
+      await checkMaxDataSizeWarningForConfig(defaultConfig, false);
     });
 
     describe('environment variables', () => {

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -626,7 +626,7 @@ describe('Debuglet', () => {
          debuglet.on('initError', (err: Error) => {
            const errorMessage = 'The working directory is a root ' +
                'directory. Disabling to avoid a scan of the entire filesystem ' +
-               'for JavaScript files. Use config \allowRootAsWorkingDirectory` ' +
+               'for JavaScript files. Use config `allowRootAsWorkingDirectory` ' +
                'if you really want to do this.';
            assert.ok(err);
            assert.strictEqual(err.message, errorMessage);


### PR DESCRIPTION
This allows us to properly represent objects with circular references in Node 10+, unless `capture.maxDataSize=0`, which will only be fixed once `stableObjectId` is introduced in Node 10. See #516

- [x] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
