### PR TITLE
chore: update `teeny-request`

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "semver": "^5.5.0",
     "source-map": "^0.6.1",
     "split": "^1.0.0",
-    "teeny-request": "^3.6.0"
+    "teeny-request": "^3.11.1"
   },
   "scripts": {
     "changelog": "npm run compile && ./bin/run-changelog.sh",


### PR DESCRIPTION
`teeny-request` needs to be updated to address the following
compiler error:
```
src/client/stackdriver/debug.ts:61:22 - error TS2352:
  Conversion of type 'typeof teenyRequest' to type
  'RequestAPI<Request, CoreOptions, RequiredUriUrl>' may be a
  mistake because neither type sufficiently overlaps with the
  other.  If this was intentional, convert the expression to
  'unknown' first.
    Property 'get' is missing in type 'typeof teenyRequest'.
```
