### PR TITLE
chore: remove `broken-link-checker-local` as dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "require-inject": "^1.4.3",
     "source-map-support": "^0.5.6",
     "typescript": "~3.3.0",
-    "uuid": "^3.3.2",
-    "broken-link-checker-local": "^0.2.0"
+    "uuid": "^3.3.2"
   },
   "dependencies": {
     "@google-cloud/common": "^0.27.0",


### PR DESCRIPTION
The `string` module has a high security vulnerability
and is a dependency of `broken-link-checker-local`.  Since
we don't actually use the `broken-link-checker-local` module,
it is being removed.