### PR TITLE
chore: add samples code

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
   "scripts": {
     "changelog": "npm run compile && ./bin/run-changelog.sh",
     "prepare": "npm run compile",
+    "presamples-test": "npm run compile",
+    "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
     "presystem-test": "npm run compile",
     "system-test": "mocha build/system-test",
     "test-no-cover": "cross-env CLOUD_DEBUG_ASSERTIONS=1 mocha build/test --require source-map-support/register --timeout 4000 --R spec",
@@ -94,7 +96,6 @@
     "license-check": "jsgl --local .",
     "lint": "npm run check",
     "docs": "compodoc src/",
-    "samples-test": "mocha samples/system-test",
     "docs-test": "blcl docs -r --exclude www.googleapis.com",
     "predocs-test": "npm run docs"
   },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "changelog": "npm run compile && ./bin/run-changelog.sh",
     "prepare": "npm run compile",
     "presamples-test": "npm run compile",
-    "samples-test": "cd samples/ && npm link ../ && npm test && cd ../",
+    "samples-test": "cd samples/ && npm link ../ && npm install && npm test && cd ../",
     "presystem-test": "npm run compile",
     "system-test": "mocha build/system-test",
     "test-no-cover": "cross-env CLOUD_DEBUG_ASSERTIONS=1 mocha build/test --require source-map-support/register --timeout 4000 --R spec",
@@ -98,7 +98,6 @@
     "license-check": "jsgl --local .",
     "lint": "npm run check",
     "docs": "compodoc src/",
-    "samples-test": "mocha samples/system-test",
     "docs-test": "linkinator docs -r --skip www.googleapis.com",
     "predocs-test": "npm run docs"
   },

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,70 @@
+# StackDriver Debugger sample for Node.js
+
+This sample demonstrates [StackDriver Debugger][debugger] with Node.js.
+
+* [Setup](#setup)
+* [Running locally](#running-locally)
+* [Deploying to App Engine](#deploying-to-app-engine)
+* [Running the tests](#running-the-tests)
+
+## Setup
+
+Before you can run or deploy the sample, you need to do the following (where
+appropriate, replace `YOUR_PROJECT_ID` with the ID of your Cloud project):
+
+1.  Refer to the [appengine/README.md][readme] file for instructions on
+    running and deploying.
+
+1. Set the `GCLOUD_PROJECT` environment variable:
+
+    Linux:
+
+        export GCLOUD_PROJECT=your-project-id
+
+    Windows:
+
+        set GCLOUD_PROJECT=your-project-id
+
+    Windows (PowerShell):
+
+        $env:GCLOUD_PROJECT="your-project-id"
+
+1.  Acquire local credentials for authenticating with Google Cloud Platform APIs:
+
+        gcloud auth application-default login
+
+1.  Configure git to use gcloud SDK:
+
+        git config credential.helper gcloud.sh
+
+1.  Add your Cloud Source Repository as a git remote:
+
+        git remote add google https://source.developers.google.com/p/YOUR_PROJECT_ID/r/default
+
+1.  Commit and push the code into the Cloud Source Repository:
+
+        git add -A && git commit -m "Initial commit" && git push --all google
+
+1.  Install dependencies:
+
+        npm install
+
+## Running locally
+
+    npm start
+
+
+## Deploying to App Engine
+
+    npm run deploy
+
+
+Use the [Stackdriver Debugger dashboard](https://console.cloud.google.com/debug) to inspect runtime data of the app.
+
+## Running the tests
+
+See [Contributing][contributing].
+
+[debugger]: https://cloud.google.com/debugger/
+[readme]: ../README.md
+[contributing]: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/master/CONTRIBUTING.md

--- a/samples/README.md
+++ b/samples/README.md
@@ -12,7 +12,7 @@ This sample demonstrates [StackDriver Debugger][debugger] with Node.js.
 Before you can run or deploy the sample, you need to do the following (where
 appropriate, replace `YOUR_PROJECT_ID` with the ID of your Cloud project):
 
-1.  Refer to the [App Engine Quickstart][quickstart] for instructions on
+1.  Refer to the `@google-cloud/debug-agent` [README][readme] for instructions on
     running and deploying.
 
 1. Set the `GCLOUD_PROJECT` environment variable:
@@ -66,5 +66,5 @@ Use the [Stackdriver Debugger dashboard](https://console.cloud.google.com/debug)
 See [Contributing][contributing].
 
 [debugger]: https://cloud.google.com/debugger/
-[quickstart]: https://cloud.google.com/appengine/docs/standard/nodejs/quickstart
+[readme]: ../README.md
 [contributing]: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/master/CONTRIBUTING.md

--- a/samples/README.md
+++ b/samples/README.md
@@ -12,7 +12,7 @@ This sample demonstrates [StackDriver Debugger][debugger] with Node.js.
 Before you can run or deploy the sample, you need to do the following (where
 appropriate, replace `YOUR_PROJECT_ID` with the ID of your Cloud project):
 
-1.  Refer to the [appengine/README.md][readme] file for instructions on
+1.  Refer to the [App Engine Quickstart][quickstart] for instructions on
     running and deploying.
 
 1. Set the `GCLOUD_PROJECT` environment variable:
@@ -66,5 +66,5 @@ Use the [Stackdriver Debugger dashboard](https://console.cloud.google.com/debug)
 See [Contributing][contributing].
 
 [debugger]: https://cloud.google.com/debugger/
-[readme]: ../README.md
+[quickstart]: https://cloud.google.com/appengine/docs/standard/nodejs/quickstart
 [contributing]: https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/master/CONTRIBUTING.md

--- a/samples/app.js
+++ b/samples/app.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2017, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// [START debugger_app]
+'use strict';
+
+// [START debugger_setup_implicit]
+require('@google-cloud/debug-agent').start();
+// [END debugger_setup_implicit]
+
+const express = require('express');
+const app = express();
+
+app.enable('trust proxy');
+
+app.get('/', (req, res) => {
+  // Try using the StackDriver Debugger dashboard to inspect the "req" object
+  res.status(200).send('Hello, world!');
+});
+
+// Start the server
+if (module === require.main) {
+  const PORT = process.env.PORT || 8080;
+  app.listen(PORT, () => {
+    console.log(`App listening on port ${PORT}`);
+    console.log('Press Ctrl+C to quit.');
+  });
+}
+// [END debugger_app]
+
+module.exports = app;

--- a/samples/app.yaml
+++ b/samples/app.yaml
@@ -1,0 +1,16 @@
+# Copyright 2015-2016, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START app_yaml]
+runtime: nodejs10
+# [END app_yaml]

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,19 +1,38 @@
 {
-  "description": "Samples for the googleapis/cloud-debug-nodejs npm module.",
+  "name": "nodejs-docs-samples-debugger",
+  "description": "Sample for Google Stackdriver Trace on Google App Engine Flexible Environment.",
+  "version": "0.0.1",
+  "private": true,
   "license": "Apache-2.0",
-  "author": "Google LLC",
+  "author": "Google Inc.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
+  },
   "engines": {
     "node": ">=8"
   },
-  "repository": "googleapis/cloud-debug-nodejs",
-  "private": true,
   "scripts": {
-    "test": "mocha system-test"
+    "deploy": "gcloud app deploy",
+    "start": "node app.js",
+    "system-test": "repo-tools test app",
+    "test": "npm run system-test",
+    "e2e-test": "repo-tools test deploy"
   },
   "dependencies": {
-    "@google-cloud/debug-agent": "^3.0.1"
+    "@google-cloud/debug-agent": "3.0.1",
+    "express": "4.16.4"
   },
   "devDependencies": {
-    "mocha": "^5.2.0"
+    "@google-cloud/nodejs-repo-tools": "^3.0.0"
+  },
+  "cloud-repo-tools": {
+    "test": {
+      "app": {
+        "msg": "Hello, world!"
+      }
+    },
+    "requiresKeyFile": true,
+    "requiresProjectId": true
   }
 }

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -1,8 +1,0 @@
-/**
- * Copyright 2018 Google LLC
- *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
- */
-
-console.warn(`no samples available 🤮`);

--- a/samples/snippets.js
+++ b/samples/snippets.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2017, Google, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+// [START debugger_setup_explicit]
+require('@google-cloud/debug-agent').start({
+  projectId: 'your-project-id',
+  keyFilename: '/path/to/key.json',
+});
+// [END debugger_setup_explicity]

--- a/samples/system-test/test.js
+++ b/samples/system-test/test.js
@@ -1,8 +1,0 @@
-/**
- * Copyright 2018 Google LLC
- *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
- */
-
-console.warn(`no sample tests available 🤮`);


### PR DESCRIPTION
The samples from

https://github.com/GoogleCloudPlatform/nodejs-docs-samples/tree/master/debugger

have been migrated to this library.

Fixes: #577 