### PR TITLE
feat: make logpoint function customizable

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -290,6 +290,13 @@ export interface ResolvedDebugAgentConfig extends GoogleAuthOptions {
      * logging resumes per logpoint.
      */
     logDelaySeconds: number;
+
+    /**
+     * By default log-points are printed using console.log. If necessary, one
+     * can provide a custom log point printing function. This may be useful in
+     * cases where you want to log to 3rd part logging service.
+     */
+    logFunction: (message: string) => void;
   };
 
   /**
@@ -347,7 +354,7 @@ export const defaultConfig: ResolvedDebugAgentConfig = {
     maxStringLength: 100
   },
 
-  log: {maxLogsPerSecond: 50, logDelaySeconds: 1},
+  log: {maxLogsPerSecond: 50, logDelaySeconds: 1, logFunction: console.log},
 
   internal: {
     registerDelayOnFetcherErrorSec: 300,  // 5 minutes.

--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -830,7 +830,8 @@ export class Debuglet extends EventEmitter {
             .log(
                 breakpoint,
                 (fmt: string, exprs: string[]) => {
-                  console.log('LOGPOINT:', Debuglet.format(fmt, exprs));
+                  that.config.log.logFunction(
+                      `LOGPOINT: ${Debuglet.format(fmt, exprs)}`);
                 },
                 () => {
                   // TODO: Address the case when `breakpoint.id` is `undefined`.

--- a/system-test/test-e2e.ts
+++ b/system-test/test-e2e.ts
@@ -29,8 +29,10 @@ const FILENAME = 'build/test/fixtures/fib.js';
 
 const UUID = uuid.v4();
 const LOG_MESSAGE_FORMAT = UUID + ': o is: $0';
+
+// fib.js uses a custom log-point function that lower cases everything.
 const REGEX =
-    new RegExp(`LOGPOINT: ${UUID}: o is: {"a":\\[1,"hi",true\\]}`, 'g');
+    new RegExp(`logpoint: ${UUID}: o is: {"a":\\[1,"hi",true\\]}`, 'g');
 
 const delay = (delayTimeMS: number): Promise<void> => {
   return new Promise(r => setTimeout(r, delayTimeMS));
@@ -259,7 +261,7 @@ describe('@google-cloud/debug end-to-end behavior', () => {
     console.log('-- checking log point was hit again');
     children.forEach((child) => {
       const count = (child.transcript.match(REGEX) || []).length;
-      assert.ok(count > 60, `expected count ${count} to be > 60`);
+      assert.ok(count > 20, `expected count ${count} to be > 20`);
     });
     console.log('-- test passed');
   }

--- a/test/fixtures/fib.js
+++ b/test/fixtures/fib.js
@@ -33,8 +33,14 @@ const UUID = process.argv[2] || uuid.v4();
 var debuglet = require('../../..').start({
   debug: {
     logLevel: 2,
-    maxLogsPerSecond: 2,
-    logDelaySeconds: 5,
+    log: {
+      maxLogsPerSecond: 2,
+      logDelaySeconds: 5,
+      // Use a custom logpoint function that converts everything lower case.
+      logFunction: (message) => {
+        console.log(message.toLowerCase())
+      }
+    },
     breakpointUpdateIntervalSec: 1,
     testMode_: true,
     allowExpressions: true,


### PR DESCRIPTION
By default we use console.log for printing logpoint messages. This PR
adds a config option to allow users to customize the log function. This
can be useful in situations where the logs are being sent to 3rd parties
or need post-processing.

Fixes: https://github.com/googleapis/cloud-debug-nodejs/issues/458
