### PR TITLE
test: use unique service context for e2e tests

### DIFF
--- a/src/debuggee.ts
+++ b/src/debuggee.ts
@@ -52,6 +52,7 @@ export class Debuggee {
   // TODO: This doesn't seem to ever be set but is referenced in the
   //       debuglet.ts file.
   isDisabled?: boolean;
+  isInactive?: boolean;
 
   /**
    * Creates a Debuggee service object.

--- a/system-test/test-e2e.ts
+++ b/system-test/test-e2e.ts
@@ -98,9 +98,11 @@ describe('@google-cloud/debug end-to-end behavior', () => {
 
       for (let i = 0; i < CLUSTER_WORKERS; i++) {
         // Fork child processes that sned messages to this process with IPC.
+        // We pass UUID to the children so that they can all get the same
+        // debuggee id.
         const child: Child = {transcript: ''};
         child.process = cp.fork(
-            FILENAME, /* args */[],
+            FILENAME, /* args */[UUID],
             {execArgv: [], env: process.env, silent: true});
         child.process.on('message', handler);
 

--- a/system-test/test-e2e.ts
+++ b/system-test/test-e2e.ts
@@ -257,7 +257,7 @@ describe('@google-cloud/debug end-to-end behavior', () => {
     console.log('-- checking log point was hit again');
     children.forEach((child) => {
       const count = (child.transcript.match(REGEX) || []).length;
-      assert.ok(count > 60);
+      assert.ok(count > 60, `expected count ${count} to be > 60`);
     });
     console.log('-- test passed');
   }

--- a/system-test/test-e2e.ts
+++ b/system-test/test-e2e.ts
@@ -139,7 +139,9 @@ describe('@google-cloud/debug end-to-end behavior', () => {
   });
 
   async function verifyDebuggeeFound() {
-    const debuggees = await api.listDebuggees(projectId!, true);
+    const allDebuggees = await api.listDebuggees(projectId!, true);
+    const debuggees =
+        allDebuggees.filter(debuggee => debuggee.isInactive !== true);
 
     // Check that the debuggee created in this test is among the list of
     // debuggees, then list its breakpoints

--- a/test/fixtures/fib.js
+++ b/test/fixtures/fib.js
@@ -21,6 +21,7 @@ function fib(n) {
  * limitations under the License.
  */
 
+const uuid = require('uuid');
 const nocks = require('../nocks.js');
 nocks.projectId('fake-project-id');
 

--- a/test/fixtures/fib.js
+++ b/test/fixtures/fib.js
@@ -28,6 +28,8 @@ nocks.projectId('fake-project-id');
 // environment.
 nocks.metadataInstance();
 
+const UUID = process.argv[2] || uuid.v4();
+
 var debuglet = require('../../..').start({
   debug: {
     logLevel: 2,
@@ -35,12 +37,9 @@ var debuglet = require('../../..').start({
     logDelaySeconds: 5,
     breakpointUpdateIntervalSec: 1,
     testMode_: true,
-    allowExpressions: true
+    allowExpressions: true,
+    description: UUID
   },
-  serviceContext: {
-    service: 'cloud-debug-system-test-service',
-    version: uuid.v4()
-  }
 });
 
 // Make troubleshooting easier if run by itself

--- a/test/fixtures/fib.js
+++ b/test/fixtures/fib.js
@@ -35,7 +35,7 @@ var debuglet = require('../../..').start({
   },
   serviceContext: {
     service: 'cloud-debug-system-test-service',
-    version: 'unversioned'
+    version: uuid.v4()
   }
 });
 

--- a/test/fixtures/fib.js
+++ b/test/fixtures/fib.js
@@ -24,6 +24,9 @@ function fib(n) {
 const uuid = require('uuid');
 const nocks = require('../nocks.js');
 nocks.projectId('fake-project-id');
+// mock the metadata instance to uniformly make this look like a non-gcp
+// environment.
+nocks.metadataInstance();
 
 var debuglet = require('../../..').start({
   debug: {

--- a/test/nocks.ts
+++ b/test/nocks.ts
@@ -53,3 +53,9 @@ export function projectId(reply: string): nock.Scope {
       .once()
       .reply(200, reply);
 }
+
+export function metadataInstance(): nock.Scope {
+  return nock('http://metadata.google.internal/')
+      .get('/computeMetadata/v1/instance')
+      .replyWithError({code: 'ENOTFOUND', message: 'nocked request'});
+}


### PR DESCRIPTION
Concurrent execution of the e2e tests is causing flakiness.
