### PR TITLE
test: add smoke test for app sample

### DIFF
--- a/samples/app.js
+++ b/samples/app.js
@@ -28,12 +28,8 @@ app.get('/', (req, res) => {
 });
 
 // Start the server
-if (module === require.main) {
-  const PORT = process.env.PORT || 8080;
-  app.listen(PORT, () => {
-    console.log(`App listening on port ${PORT}`);
-    console.log('Press Ctrl+C to quit.');
-  });
-}
-
-module.exports = app;
+const PORT = process.env.PORT || 8080;
+app.listen(PORT, () => {
+  console.log(`App listening on port ${PORT}`);
+  console.log('Press Ctrl+C to quit.');
+});

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,39 +1,24 @@
 {
   "name": "nodejs-docs-samples-debugger",
   "description": "Sample for Google Stackdriver Trace on Google App Engine Flexible Environment.",
-  "version": "0.0.1",
   "private": true,
   "license": "Apache-2.0",
-  "author": "Google Inc.",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/GoogleCloudPlatform/nodejs-docs-samples.git"
-  },
+  "author": "Google LLC",
+  "repository": "googleapis/cloud-debug-nodejs",
   "engines": {
     "node": ">=8"
   },
   "scripts": {
     "deploy": "gcloud app deploy",
     "start": "node app.js",
-    "system-test": "repo-tools test app",
-    "test": "npm run system-test",
-    "e2e-test": "repo-tools test deploy"
+    "test": "mocha"
   },
   "dependencies": {
     "@google-cloud/debug-agent": "^3.1.0",
     "express": "4.16.4"
   },
   "devDependencies": {
-    "@google-cloud/nodejs-repo-tools": "^3.0.0",
+    "execa": "^1.0.0",
     "mocha": "^6.0.0"
-  },
-  "cloud-repo-tools": {
-    "test": {
-      "app": {
-        "msg": "Hello, world!"
-      }
-    },
-    "requiresKeyFile": true,
-    "requiresProjectId": true
   }
 }

--- a/samples/test/test.js
+++ b/samples/test/test.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2019, Google, LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const execa = require('execa');
+
+describe('debug samples', () => {
+
+  it('should run the quickstart', done => {
+    // select a random port between 49152 and 65535
+    const PORT = Math.floor((Math.random() * (65535-49152))) + 49152;
+    const proc = execa('node', ['app.js'], {
+      env: {
+        PORT
+      }
+    });
+    proc.stdout.on('data', message => {
+      // Listen to stdout and look for messages.  If we get a `Press CTRL+...`
+      // assume the process started.  Wait a second to make sure there
+      // is no stderr output signifying something may have gone wrong.
+      message = message.toString('utf8');
+      if (/Press Ctrl/.test(message)) {
+        setTimeout(() => {
+          proc.kill();
+          done();
+        }, 1000);
+      }
+    })
+    proc.stderr.on('data', message => {
+      // if anything comes through stderr, assume a bug
+      done(new Error(message.toString('utf8')));
+    });
+  });
+
+});


### PR DESCRIPTION
There are currently no tests available for the samples.  This cleans up a few things and adds a simple test.  In addition removes `@google-cloud/repo-tools` and it's configuration as it wasn't being used.
