### PR TITLE
chore: drop duplicate nyc config

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,14 +105,5 @@
     "LICENSE",
     "README.md",
     "build/src"
-  ],
-  "nyc": {
-    "reporter": [
-      "lcov"
-    ],
-    "exclude": [
-      "build/test/*-code.js",
-      "build/test/fixtures/**/*.js"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
This is already covered in the `.nycrc` we bring into every repository.  @bcoe is working on fixes in the common file to keep us all consistent and happy :)