### PR TITLE
build: patch Windows container, fixing Node 10

### DIFF
--- a/.kokoro/test.bat
+++ b/.kokoro/test.bat
@@ -17,7 +17,15 @@
 cd /d %~dp0
 cd ..
 
-call npm install -g npm@latest || goto :error
+@rem The image we're currently running has a broken version of Node.js enabled
+@rem by nvm (v10.15.3), which has no npm bin. This hack uses the functional
+@rem Node v8.9.1 to install npm@latest, it then uses this version of npm to
+@rem install npm for v10.15.3.
+call nvm use v8.9.1 || goto :error
+call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm-bootstrap\bin\npm-cli.js i npm -g || goto :error
+call nvm use v10.15.3 || goto :error
+call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm\bin\npm-cli.js i npm -g || goto :error
+
 call npm install || goto :error
 call npm run test || goto :error
 

--- a/.kokoro/test.bat
+++ b/.kokoro/test.bat
@@ -23,8 +23,6 @@ cd ..
 @rem install npm for v10.15.3.
 call nvm use v8.9.1 || goto :error
 call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm-bootstrap\bin\npm-cli.js i npm -g || goto :error
-call nvm use v10.15.3 || goto :error
-call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm\bin\npm-cli.js i npm -g || goto :error
 
 call npm install || goto :error
 call npm run test || goto :error

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "samples-test": "cd samples/ && npm link ../ && npm install && npm test && cd ../",
     "presystem-test": "npm run compile",
     "system-test": "mocha build/system-test",
-    "test-no-cover": "cross-env CLOUD_DEBUG_ASSERTIONS=1 mocha build/test --require source-map-support/register --timeout 4000 --R spec",
+    "test-no-cover": "cross-env CLOUD_DEBUG_ASSERTIONS=1 mocha build/test --require source-map-support/register --timeout 8000 --R spec",
     "test": "nyc npm run test-no-cover && nyc report",
     "check": "gts check",
     "clean": "gts clean",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "samples-test": "cd samples/ && npm link ../ && npm install && npm test && cd ../",
     "presystem-test": "npm run compile",
     "system-test": "mocha build/system-test",
-    "test-no-cover": "cross-env CLOUD_DEBUG_ASSERTIONS=1 mocha build/test --require source-map-support/register --timeout 8000 --R spec",
+    "test-no-cover": "cross-env CLOUD_DEBUG_ASSERTIONS=1 mocha build/test --require source-map-support/register --timeout 4000 --R spec",
     "test": "nyc npm run test-no-cover && nyc report",
     "check": "gts check",
     "clean": "gts clean",

--- a/synth.py
+++ b/synth.py
@@ -22,3 +22,6 @@ common_templates = gcp.CommonTemplates()
 
 templates = common_templates.node_library()
 s.copy(templates)
+s.copy(templates, excludes=[
+  '.kokoro/test.sh'
+])

--- a/synth.py
+++ b/synth.py
@@ -21,7 +21,8 @@ logging.basicConfig(level=logging.DEBUG)
 common_templates = gcp.CommonTemplates()
 
 templates = common_templates.node_library()
-s.copy(templates)
+# stop excluding '.kokoro/test.bat' as soon as we figure out why Node 10 tests
+# have issues on Windows (see #686).
 s.copy(templates, excludes=[
-  '.kokoro/test.sh'
+  '.kokoro/test.bat'
 ])


### PR DESCRIPTION
temporary patch broken Windows container, such that tests can be run on Node 10