### PR TITLE
build: patch Windows container, fixing Node 10

### DIFF
--- a/.kokoro/test.bat
+++ b/.kokoro/test.bat
@@ -23,6 +23,8 @@ cd ..
 @rem install npm for v10.15.3.
 call nvm use v8.9.1 || goto :error
 call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm-bootstrap\bin\npm-cli.js i npm -g || goto :error
+call nvm use v10.15.3 || goto :error
+call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm\bin\npm-cli.js i npm -g || goto :error
 
 call npm install || goto :error
 call npm run test || goto :error


### PR DESCRIPTION
temporary patch broken Windows container, such that tests can be run on Node 10