### PR TITLE
feat: add `get()` function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,3 +69,10 @@ function mergeConfigs<T>(options: T & {debug?: T}): T {
   delete result.debug;
   return Object.assign(result, options.debug);
 }
+
+/* Used to access the agent if it has been started.  Returns the agent
+ * if the agent has been started.  Otherwise, `undefined` is returned.
+ */
+export function get(): Debuglet | undefined {
+  return debuglet;
+}

--- a/test/test-module.ts
+++ b/test/test-module.ts
@@ -15,9 +15,10 @@
  */
 
 import * as assert from 'assert';
-const m: NodeModule & {start: Function} = require('../..');
+const m: NodeModule & {start: Function, get: () => Debuglet|undefined} = require('../..');
 import * as nock from 'nock';
 import * as nocks from './nocks';
+import { Debuglet } from '../src/agent/debuglet';
 
 nock.disableNetConnect();
 
@@ -38,5 +39,18 @@ describe('Debug module', () => {
     assert.throws(() => {
       m.start();
     });
+  });
+
+  it('should return the agent via the get() method', () => {
+    const agent = m.get();
+    assert(agent, 'Expected to get the started agent');
+    assert.strictEqual(agent!.config.projectId, '0');
+  });
+});
+
+describe('Debug module without start() called', () => {
+  it('get() should return `undefined`', () => {
+    const agent = m.get();
+    assert.strictEqual(agent, undefined, 'Expected `undefined` since the agent was not started');
   });
 });

--- a/test/test-module.ts
+++ b/test/test-module.ts
@@ -15,10 +15,13 @@
  */
 
 import * as assert from 'assert';
-const m: NodeModule & {start: Function, get: () => Debuglet|undefined} = require('../..');
+const m: NodeModule & {
+  start: Function;
+  get: () => Debuglet | undefined;
+} = require('../..');
 import * as nock from 'nock';
 import * as nocks from './nocks';
-import { Debuglet } from '../src/agent/debuglet';
+import {Debuglet} from '../src/agent/debuglet';
 
 nock.disableNetConnect();
 
@@ -51,6 +54,10 @@ describe('Debug module', () => {
 describe('Debug module without start() called', () => {
   it('get() should return `undefined`', () => {
     const agent = m.get();
-    assert.strictEqual(agent, undefined, 'Expected `undefined` since the agent was not started');
+    assert.strictEqual(
+      agent,
+      undefined,
+      'Expected `undefined` since the agent was not started'
+    );
   });
 });

--- a/test/test-module.ts
+++ b/test/test-module.ts
@@ -53,6 +53,11 @@ describe('Debug module', () => {
 
 describe('Debug module without start() called', () => {
   it('get() should return `undefined`', () => {
+    delete require.cache[require.resolve('../..')];
+    const m: NodeModule & {
+      start: Function;
+      get: () => Debuglet | undefined;
+    } = require('../..');
     const agent = m.get();
     assert.strictEqual(
       agent,


### PR DESCRIPTION
The `get()` function is used to access an agent if it
has been started.