### PR TITLE
feat: Introduce javascriptFileExtensions config parameter

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -180,6 +180,15 @@ export interface ResolvedDebugAgentConfig extends GoogleAuthOptions {
   appPathRelativeToRepository?: string;
 
   /**
+   * The set of file extensions that identify javascript code to be debugged.
+   * By default, only .js files or files with sourcemaps are considered to be
+   * debuggable. This setting can be used to inform the debugger if you have
+   * javascript code in files with extensions other than .js.
+   * Example: ['.js', '.jsz']
+   */
+  javascriptFileExtensions: string[];
+
+  /**
    * A function which takes the path of a source file in your repository,
    * a list of your project's Javascript files known to the debugger,
    * and the file(s) in your project that the debugger thinks is identified
@@ -362,6 +371,7 @@ export const defaultConfig: ResolvedDebugAgentConfig = {
   },
 
   appPathRelativeToRepository: undefined,
+  javascriptFileExtensions: ['.js'],
   pathResolver: undefined,
   logLevel: 1,
   breakpointUpdateIntervalSec: 10,

--- a/src/agent/v8/inspector-debugapi.ts
+++ b/src/agent/v8/inspector-debugapi.ts
@@ -136,7 +136,8 @@ export class InspectorDebugApi implements debugapi.DebugApi {
     }
     const baseScriptPath = path.normalize(breakpoint.location.path);
     if (!this.sourcemapper.hasMappingInfo(baseScriptPath)) {
-      if (!baseScriptPath.endsWith('js')) {
+      const extension = path.extname(baseScriptPath);
+      if (!this.config.javascriptFileExtensions.includes(extension)) {
         return utils.setErrorStatusAndCallback(
           cb,
           breakpoint,

--- a/src/agent/v8/legacy-debugapi.ts
+++ b/src/agent/v8/legacy-debugapi.ts
@@ -132,7 +132,8 @@ export class V8DebugApi implements debugapi.DebugApi {
     }
     const baseScriptPath = path.normalize(breakpoint.location.path);
     if (!this.sourcemapper.hasMappingInfo(baseScriptPath)) {
-      if (!baseScriptPath.endsWith('.js')) {
+      const extension = path.extname(baseScriptPath);
+      if (!this.config.javascriptFileExtensions.includes(extension)) {
         return utils.setErrorStatusAndCallback(
           cb,
           breakpoint,

--- a/test/fixtures/hello.jsz
+++ b/test/fixtures/hello.jsz
@@ -1,0 +1,1 @@
+console.log('hello world');

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -91,12 +91,12 @@ describe('Debuglet', () => {
     const SOURCEMAP_DIR = path.join(__dirname, 'fixtures', 'sourcemaps');
 
     it('throws an error for an invalid directory', async () => {
+      const config = extend({}, defaultConfig, {
+        workingDirectory: path.join(SOURCEMAP_DIR, '!INVALID'),
+      });
       let err: Error | null = null;
       try {
-        await Debuglet.findFiles(
-          path.join(SOURCEMAP_DIR, '!INVALID!'),
-          'fake-id'
-        );
+        await Debuglet.findFiles(config, 'fake-id');
       } catch (e) {
         err = e;
       }
@@ -104,7 +104,10 @@ describe('Debuglet', () => {
     });
 
     it('finds the correct sourcemaps files', async () => {
-      const searchResults = await Debuglet.findFiles(SOURCEMAP_DIR, 'fake-id');
+      const config = extend({}, defaultConfig, {
+        workingDirectory: SOURCEMAP_DIR,
+      });
+      const searchResults = await Debuglet.findFiles(config, 'fake-id');
       assert(searchResults.jsStats);
       assert.strictEqual(Object.keys(searchResults.jsStats).length, 1);
       assert(searchResults.jsStats[path.join(SOURCEMAP_DIR, 'js-file.js')]);
@@ -717,9 +720,10 @@ describe('Debuglet', () => {
       // Don't actually scan the entire filesystem.  Act like the filesystem
       // is empty.
       mockedDebuglet.Debuglet.findFiles = (
-        baseDir: string,
+        config: ResolvedDebugAgentConfig,
         precomputedHash?: string
       ): Promise<FindFilesResult> => {
+        const baseDir = config.workingDirectory;
         assert.strictEqual(baseDir, root);
         return Promise.resolve({
           jsStats: {},


### PR DESCRIPTION
This config parameter can be used to allow users to debug javascript
files that have extensions other than .js

Fixes #777 🦕
