### PR TITLE
test: re-enable windows tests

### DIFF
--- a/.kokoro/test.bat
+++ b/.kokoro/test.bat
@@ -23,6 +23,8 @@ cd ..
 @rem install npm for v10.15.3.
 call nvm use v8.9.1 || goto :error
 call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm-bootstrap\bin\npm-cli.js i npm -g || goto :error
+call nvm use v10.15.3 || goto :error
+call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm\bin\npm-cli.js i npm -g || goto :error
 
 call npm install || goto :error
 call npm run test || goto :error

--- a/synth.py
+++ b/synth.py
@@ -20,11 +20,7 @@ import subprocess
 logging.basicConfig(level=logging.DEBUG)
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library()
-# stop excluding '.kokoro/test.bat' as soon as we figure out why Node 10 tests
-# have issues on Windows (see #686).
-s.copy(templates, excludes=[
-  '.kokoro/test.bat'
-])
+s.copy(templates)
 
 subprocess.run(['npm', 'install'])
 subprocess.run(['npm', 'run', 'fix'])


### PR DESCRIPTION
@DominicKramer we'd like to move this library to GA, but I want to make sure we clean up the issues with Windows tests first.  Mind taking a look at this and seeing what's going on?