### PR TITLE
fix: breakpoints work on windows

### DIFF
--- a/.kokoro/test.bat
+++ b/.kokoro/test.bat
@@ -17,12 +17,12 @@
 cd /d %~dp0
 cd ..
 
-@rem The image we're currently running has a broken version of Node.js enabled
-@rem by nvm (v10.15.3), which has no npm bin. This hack uses the functional
-@rem Node v8.9.1 to install npm@latest, it then uses this version of npm to
-@rem install npm for v10.15.3.
-call nvm use v8.9.1 || goto :error
-call node C:\Users\kbuilder\AppData\Roaming\nvm-ps\versions\v8.9.1\node_modules\npm-bootstrap\bin\npm-cli.js i npm -g || goto :error
+@rem npm path is not currently set in our image, we should fix this next time
+@rem we upgrade Node.js in the image:
+SET PATH=%PATH%;/cygdrive/c/Program Files/nodejs/npm
+
+call nvm use v12.14.1
+call which node
 
 call npm install || goto :error
 call npm run test || goto :error

--- a/src/agent/state/inspector-state.ts
+++ b/src/agent/state/inspector-state.ts
@@ -36,6 +36,10 @@ const FILE_PROTOCOL = 'file://';
 // on windows on Node 11+ the file protocol needs to have three slashes
 const WINDOWS_FILE_PROTOCOL = 'file:///';
 
+// Used to match paths like file:///C:/... on windows
+// but do not match paths like file:///home/... on linux
+const WINDOWS_URL_REGEX = RegExp(`^${WINDOWS_FILE_PROTOCOL}[a-zA-Z]+:`);
+
 const STABLE_OBJECT_ID_PROPERTY = '[[StableObjectId]]';
 const NO_STABLE_OBJECT_ID = -1;
 
@@ -334,9 +338,7 @@ class StateResolver {
 
   static stripFileProtocol_(path: string) {
     const lowerPath = path.toLowerCase();
-    // match paths like file:///C:/... on windows
-    // but do not match paths like file:///home/... on linux
-    if (RegExp(`^${WINDOWS_FILE_PROTOCOL}[a-zA-Z]+:`).test(lowerPath)) {
+    if (WINDOWS_URL_REGEX.test(lowerPath)) {
       return path.substr(WINDOWS_FILE_PROTOCOL.length);
     }
 

--- a/src/agent/state/inspector-state.ts
+++ b/src/agent/state/inspector-state.ts
@@ -33,7 +33,7 @@ const GETTER_MESSAGE_INDEX = 2;
 const ARG_LOCAL_LIMIT_MESSAGE_INDEX = 3;
 
 const FILE_PROTOCOL = 'file://';
-// on windows the file protocol needs to have three slashes
+// on windows on Node 11+ the file protocol needs to have three slashes
 const WINDOWS_FILE_PROTOCOL = 'file:///';
 
 const STABLE_OBJECT_ID_PROPERTY = '[[StableObjectId]]';

--- a/src/agent/state/inspector-state.ts
+++ b/src/agent/state/inspector-state.ts
@@ -334,7 +334,9 @@ class StateResolver {
 
   static stripFileProtocol_(path: string) {
     const lowerPath = path.toLowerCase();
-    if (lowerPath.startsWith(WINDOWS_FILE_PROTOCOL)) {
+    // match paths like file:///C:/... on windows
+    // but do not match paths like file:///home/... on linux
+    if (RegExp(`^${WINDOWS_FILE_PROTOCOL}[a-zA-Z]+:`).test(lowerPath)) {
       return path.substr(WINDOWS_FILE_PROTOCOL.length);
     }
 

--- a/src/agent/v8/inspector-debugapi.ts
+++ b/src/agent/v8/inspector-debugapi.ts
@@ -495,8 +495,7 @@ export class InspectorDebugApi implements debugapi.DebugApi {
       // on windows on Node 11+, the url must start with file:///
       // (notice 3 slashes) and have all backslashes converted into forward slashes
       const url =
-        process.platform === 'win32' &&
-        utils.satisfies(process.version, '>=11')
+        process.platform === 'win32' && utils.satisfies(process.version, '>=11')
           ? rawUrl.replace(/^file:\/\//, 'file:///').replace(/\\/g, '/')
           : rawUrl;
       const res = this.v8Inspector.setBreakpointByUrl({

--- a/src/agent/v8/inspector-debugapi.ts
+++ b/src/agent/v8/inspector-debugapi.ts
@@ -489,9 +489,14 @@ export class InspectorDebugApi implements debugapi.DebugApi {
     let v8BreakpointId; // v8/inspector breakpoint id
     if (!this.locationMapper[locationStr]) {
       // The first time when a breakpoint was set to this location.
-      const url = this.inspectorOptions.useWellFormattedUrl
+      const rawUrl = this.inspectorOptions.useWellFormattedUrl
         ? `file://${matchingScript}`
         : matchingScript;
+      // on windows the url must start with file:/// (notice 3 slashes)
+      // and have all backslashes converted into forward slashes
+      const url = process.platform === 'win32'
+        ? rawUrl.replace(/^file:\/\//, 'file:///').replace(/\\/g, '/')
+        : rawUrl;
       const res = this.v8Inspector.setBreakpointByUrl({
         lineNumber: line - 1,
         url,

--- a/src/agent/v8/inspector-debugapi.ts
+++ b/src/agent/v8/inspector-debugapi.ts
@@ -496,7 +496,7 @@ export class InspectorDebugApi implements debugapi.DebugApi {
       // (notice 3 slashes) and have all backslashes converted into forward slashes
       const url =
         process.platform === 'win32' &&
-        utils.satisfies(process.version, '11.x.x')
+        utils.satisfies(process.version, '>=11')
           ? rawUrl.replace(/^file:\/\//, 'file:///').replace(/\\/g, '/')
           : rawUrl;
       const res = this.v8Inspector.setBreakpointByUrl({

--- a/src/agent/v8/inspector-debugapi.ts
+++ b/src/agent/v8/inspector-debugapi.ts
@@ -494,9 +494,10 @@ export class InspectorDebugApi implements debugapi.DebugApi {
         : matchingScript;
       // on windows the url must start with file:/// (notice 3 slashes)
       // and have all backslashes converted into forward slashes
-      const url = process.platform === 'win32'
-        ? rawUrl.replace(/^file:\/\//, 'file:///').replace(/\\/g, '/')
-        : rawUrl;
+      const url =
+        process.platform === 'win32'
+          ? rawUrl.replace(/^file:\/\//, 'file:///').replace(/\\/g, '/')
+          : rawUrl;
       const res = this.v8Inspector.setBreakpointByUrl({
         lineNumber: line - 1,
         url,

--- a/src/agent/v8/inspector-debugapi.ts
+++ b/src/agent/v8/inspector-debugapi.ts
@@ -492,10 +492,11 @@ export class InspectorDebugApi implements debugapi.DebugApi {
       const rawUrl = this.inspectorOptions.useWellFormattedUrl
         ? `file://${matchingScript}`
         : matchingScript;
-      // on windows the url must start with file:/// (notice 3 slashes)
-      // and have all backslashes converted into forward slashes
+      // on windows on Node 11+, the url must start with file:///
+      // (notice 3 slashes) and have all backslashes converted into forward slashes
       const url =
-        process.platform === 'win32'
+        process.platform === 'win32' &&
+        utils.satisfies(process.version, '11.x.x')
           ? rawUrl.replace(/^file:\/\//, 'file:///').replace(/\\/g, '/')
           : rawUrl;
       const res = this.v8Inspector.setBreakpointByUrl({

--- a/synth.py
+++ b/synth.py
@@ -20,11 +20,7 @@ import subprocess
 logging.basicConfig(level=logging.DEBUG)
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library()
-# stop excluding '.kokoro/test.bat' as soon as we figure out why Node 10 tests
-# have issues on Windows (see #686).
-s.copy(templates, excludes=[
-  '.kokoro/test.bat'
-])
+s.copy(templates)
 
 subprocess.run(['npm', 'install'])
 subprocess.run(['npm', 'run', 'fix'])


### PR DESCRIPTION
On Windows, on Node 11+, the URL provided to the inspector API must start with
file:/// instead of file:// and all backslashes must be converted to forward slashes.
Otherwise, on Node 10 on windows, the URL must not start with file:// and must
contain backslashes.