### PR TITLE
feat: add auto-inferred platform label

### DIFF
--- a/src/agent/debuglet.ts
+++ b/src/agent/debuglet.ts
@@ -555,7 +555,7 @@ export class Debuglet extends EventEmitter {
       'agent.name': packageInfo.name,
       'agent.version': packageInfo.version,
       projectid: projectId,
-      platform: Debuglet.getPlatform()
+      platform: Debuglet.getPlatform(),
     };
 
     if (serviceContext) {
@@ -616,7 +616,7 @@ export class Debuglet extends EventEmitter {
     return new Debuggee(properties);
   }
 
-  /** 
+  /**
    * Use environment vars to infer the current platform.
    * For now this is only Cloud Functions and other.
    */

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -26,7 +26,12 @@ import * as stackdriver from '../src/types/stackdriver';
 
 DEFAULT_CONFIG.allowExpressions = true;
 DEFAULT_CONFIG.workingDirectory = path.join(__dirname, '..', '..');
-import {Debuglet, CachedPromise, FindFilesResult, Platforms} from '../src/agent/debuglet';
+import {
+  Debuglet,
+  CachedPromise,
+  FindFilesResult,
+  Platforms,
+} from '../src/agent/debuglet';
 import {ScanResults} from '../src/agent/io/scanner';
 import * as extend from 'extend';
 import {Debug} from '../src/client/stackdriver/debug';
@@ -1478,7 +1483,6 @@ describe('Debuglet', () => {
       assert.ok(debuggee.labels);
       assert.strictEqual(debuggee.labels!.module, undefined);
       assert.strictEqual(debuggee.labels!.version, 'yellow.5');
-      assert.strictEqual
     });
 
     it('should have an error statusMessage with the appropriate arg', () => {
@@ -1558,7 +1562,7 @@ describe('Debuglet', () => {
 
     it('should correctly identify GCF (legacy) platform.', () => {
       // GCF sets this env var on older runtimes.
-      process.env.FUNCTION_NAME = "mock";
+      process.env.FUNCTION_NAME = 'mock';
       const debuggee = Debuglet.createDebuggee(
         'some project',
         'id',
@@ -1573,7 +1577,7 @@ describe('Debuglet', () => {
 
     it('should correctly identify GCF (modern) platform.', () => {
       // GCF sets this env var on modern runtimes.
-      process.env.FUNCTION_TARGET = "mock";
+      process.env.FUNCTION_TARGET = 'mock';
       const debuggee = Debuglet.createDebuggee(
         'some project',
         'id',

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -1511,7 +1511,7 @@ describe('Debuglet', () => {
       );
       assert.strictEqual(debuggee.canaryMode, 'CANARY_MODE_DEFAULT_ENABLED');
     });
-    
+
     it('should be in CANARY_MODE_ALWAYS_ENABLED canaryMode', () => {
       const debuggee = Debuglet.createDebuggee(
         'some project',

--- a/test/test-debuglet.ts
+++ b/test/test-debuglet.ts
@@ -26,7 +26,7 @@ import * as stackdriver from '../src/types/stackdriver';
 
 DEFAULT_CONFIG.allowExpressions = true;
 DEFAULT_CONFIG.workingDirectory = path.join(__dirname, '..', '..');
-import {Debuglet, CachedPromise, FindFilesResult} from '../src/agent/debuglet';
+import {Debuglet, CachedPromise, FindFilesResult, Platforms} from '../src/agent/debuglet';
 import {ScanResults} from '../src/agent/io/scanner';
 import * as extend from 'extend';
 import {Debug} from '../src/client/stackdriver/debug';
@@ -1478,6 +1478,7 @@ describe('Debuglet', () => {
       assert.ok(debuggee.labels);
       assert.strictEqual(debuggee.labels!.module, undefined);
       assert.strictEqual(debuggee.labels!.version, 'yellow.5');
+      assert.strictEqual
     });
 
     it('should have an error statusMessage with the appropriate arg', () => {
@@ -1506,7 +1507,7 @@ describe('Debuglet', () => {
       );
       assert.strictEqual(debuggee.canaryMode, 'CANARY_MODE_DEFAULT_ENABLED');
     });
-
+    
     it('should be in CANARY_MODE_ALWAYS_ENABLED canaryMode', () => {
       const debuggee = Debuglet.createDebuggee(
         'some project',
@@ -1541,6 +1542,48 @@ describe('Debuglet', () => {
         packageInfo
       );
       assert.strictEqual(debuggee.canaryMode, 'CANARY_MODE_ALWAYS_DISABLED');
+    });
+
+    it('should correctly identify default platform.', () => {
+      const debuggee = Debuglet.createDebuggee(
+        'some project',
+        'id',
+        {service: 'some-service', version: 'production'},
+        {},
+        false,
+        packageInfo
+      );
+      assert.ok(debuggee.labels!.platform === Platforms.DEFAULT);
+    });
+
+    it('should correctly identify GCF (legacy) platform.', () => {
+      // GCF sets this env var on older runtimes.
+      process.env.FUNCTION_NAME = "mock";
+      const debuggee = Debuglet.createDebuggee(
+        'some project',
+        'id',
+        {service: 'some-service', version: 'production'},
+        {},
+        false,
+        packageInfo
+      );
+      assert.ok(debuggee.labels!.platform === Platforms.CLOUD_FUNCTION);
+      delete process.env.FUNCTION_NAME; // Don't contaminate test environment.
+    });
+
+    it('should correctly identify GCF (modern) platform.', () => {
+      // GCF sets this env var on modern runtimes.
+      process.env.FUNCTION_TARGET = "mock";
+      const debuggee = Debuglet.createDebuggee(
+        'some project',
+        'id',
+        {service: 'some-service', version: 'production'},
+        {},
+        false,
+        packageInfo
+      );
+      assert.ok(debuggee.labels!.platform === Platforms.CLOUD_FUNCTION);
+      delete process.env.FUNCTION_TARGET; // Don't contaminate test environment.
     });
   });
 


### PR DESCRIPTION
Fixes #885 

Identifies current platform (GCF or default for now) and sends this to debugger service as a label.

- Enforces label properties with interface (and catch-all for custom labels)
- Creates default-labels method
 - Uses presence of `FUNCTION_NAME` or `FUNCTION_TARGET` as signs the app is running in cloud-functions, else default platform.
