### PR TITLE
feat: support breakpoint canary

### DIFF
--- a/src/agent/controller.ts
+++ b/src/agent/controller.ts
@@ -29,6 +29,7 @@ import * as stackdriver from '../types/stackdriver';
 
 export class Controller extends ServiceObject {
   private nextWaitToken: string | null;
+  private agentId: string | null;
 
   apiUrl: string;
 
@@ -41,6 +42,7 @@ export class Controller extends ServiceObject {
 
     /** @private {string} */
     this.nextWaitToken = null;
+    this.agentId = null;
 
     this.apiUrl = `https://${debug.apiEndpoint}/v2/controller`;
 
@@ -61,6 +63,7 @@ export class Controller extends ServiceObject {
       err: Error | null,
       result?: {
         debuggee: Debuggee;
+        agentId: string;
       }
     ) => void
   ): void {
@@ -70,20 +73,24 @@ export class Controller extends ServiceObject {
       json: true,
       body: {debuggee},
     };
-    this.request(options, (err, body: {debuggee: Debuggee}, response) => {
-      if (err) {
-        callback(err);
-      } else if (response!.statusCode !== 200) {
-        callback(
-          new Error('unable to register, statusCode ' + response!.statusCode)
-        );
-      } else if (!body.debuggee) {
-        callback(new Error('invalid response body from server'));
-      } else {
-        debuggee.id = body.debuggee.id;
-        callback(null, body);
+    this.request(
+      options,
+      (err, body: {debuggee: Debuggee; agentId: string}, response) => {
+        if (err) {
+          callback(err);
+        } else if (response!.statusCode !== 200) {
+          callback(
+            new Error('unable to register, statusCode ' + response!.statusCode)
+          );
+        } else if (!body.debuggee) {
+          callback(new Error('invalid response body from server'));
+        } else {
+          debuggee.id = body.debuggee.id;
+          this.agentId = body.agentId;
+          callback(null, body);
+        }
       }
-    });
+    );
   }
 
   /**
@@ -105,6 +112,9 @@ export class Controller extends ServiceObject {
     const query: stackdriver.ListBreakpointsQuery = {successOnTimeout: true};
     if (that.nextWaitToken) {
       query.waitToken = that.nextWaitToken;
+    }
+    if (that.agentId) {
+      query.agentId = that.agentId;
     }
 
     const uri =

--- a/src/types/stackdriver.ts
+++ b/src/types/stackdriver.ts
@@ -110,6 +110,7 @@ export type BreakpointId = string;
 export interface ListBreakpointsQuery {
   waitToken?: string;
   successOnTimeout?: boolean;
+  agentId?: string;
 }
 
 export interface ListBreakpointsResponse {


### PR DESCRIPTION
Fixes #882

Add support to the [breakpoint canary feature](https://cloud.google.com/debugger/docs/using/snapshots#with_canarying) in GCP.

It does the following: 
* Add a "canaryMode" (controlled by the newly added user-provided parameters "enableCanary" and "allowCanaryOverride" parameters) to the debuggee registration request: https://cloud.google.com/debugger/api/reference/rest/v2/controller.debuggees/register#response-body
* Read and store the "agentId" field in the debuggee registration response: https://cloud.google.com/debugger/api/reference/rest/v2/controller.debuggees/register#response-body
* Feed the "agentId" fields to the list breakpoints request: https://cloud.google.com/debugger/api/reference/rest/v2/controller.debuggees.breakpoints/list
